### PR TITLE
Fix connect modal on Place Bid

### DIFF
--- a/src/components/Auction/Bid.tsx
+++ b/src/components/Auction/Bid.tsx
@@ -38,7 +38,9 @@ export default function Bid({ nounId, nextMinBid }: BidProps) {
     });
   }, [nextMinBidFormatted]);
 
-  async function onSubmit(formData: FormData) {
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
     const parsedBidAmount = parseEther(formData.get("bidAmount") as string);
     createBid(nounId, parsedBidAmount);
   }
@@ -53,7 +55,7 @@ export default function Bid({ nounId, nextMinBid }: BidProps) {
 
   return (
     <div className="flex w-full flex-col gap-1">
-      <form action={onSubmit} className="flex flex-col gap-2 md:flex-row md:gap-4">
+      <form onSubmit={onSubmit} className="flex flex-col gap-2 md:flex-row md:gap-4">
         <div className="relative h-full w-full md:w-[260px]">
           <Input
             placeholder={`Ξ ${nextMinBidFormatted} or more`}


### PR DESCRIPTION
## Summary
- ensure the bid form handles submit on the client
- prevent default form behaviour so clicking **Place Bid** triggers wallet connect if not connected

## Testing
- `bun run lint` *(fails: `next: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68540a8dad9c83259039970d0f2307f6