### PR TITLE
Fix iframe modal positioning

### DIFF
--- a/src/components/ui/dialogBase.tsx
+++ b/src/components/ui/dialogBase.tsx
@@ -40,9 +40,9 @@ const DialogContent = React.forwardRef<
       ref={ref}
       onOpenAutoFocus={(e) => e.preventDefault()}
       className={cn(
-        "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-bottom data-[state=open]:slide-in-from-left-1/2",
-        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]",
-        "fixed left-[50%] top-[50%] z-50 flex h-auto max-h-[90vh] w-full min-w-0 max-w-[95vw] translate-x-[-50%] translate-y-[-50%] flex-col gap-4 overflow-hidden rounded-2xl bg-white p-0 shadow-lg duration-500 dark:border-gray-800 dark:bg-gray-950",
+        "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-bottom",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-top-[48%]",
+        "fixed inset-0 z-50 flex items-center justify-center h-auto max-h-[90vh] w-full min-w-0 max-w-[95vw] flex-col gap-4 overflow-hidden rounded-2xl bg-white p-0 shadow-lg duration-500 dark:border-gray-800 dark:bg-gray-950",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- ensure modals center correctly when nouns.com is embedded in an iframe

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858fe0933e08325932f619e4a6cec27