### PR TITLE
Fix connect modal on Place Bid

### DIFF
--- a/src/components/Auction/Bid.tsx
+++ b/src/components/Auction/Bid.tsx
@@ -2,6 +2,8 @@
 import { formatEther, parseEther } from "viem";
 import { Input } from "@/components/ui/input";
 import { useEffect, useMemo, useState } from "react";
+import { useAccount } from "wagmi";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useCreateBid } from "@/hooks/transactions/useCreateBid";
 import TransactionButton from "../TransactionButton";
 
@@ -38,8 +40,17 @@ export default function Bid({ nounId, nextMinBid }: BidProps) {
     });
   }, [nextMinBidFormatted]);
 
-  async function onSubmit(formData: FormData) {
+  const { address } = useAccount();
+  const { openConnectModal } = useConnectModal();
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
     const parsedBidAmount = parseEther(formData.get("bidAmount") as string);
+    if (!address) {
+      openConnectModal?.();
+      return;
+    }
     createBid(nounId, parsedBidAmount);
   }
 
@@ -53,7 +64,7 @@ export default function Bid({ nounId, nextMinBid }: BidProps) {
 
   return (
     <div className="flex w-full flex-col gap-1">
-      <form action={onSubmit} className="flex flex-col gap-2 md:flex-row md:gap-4">
+      <form onSubmit={onSubmit} className="flex flex-col gap-2 md:flex-row md:gap-4">
         <div className="relative h-full w-full md:w-[260px]">
           <Input
             placeholder={`Ξ ${nextMinBidFormatted} or more`}


### PR DESCRIPTION
## Summary
- trigger wallet connect in Bid form when no wallet is connected

## Testing
- `bun run lint` *(fails: `next: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68540a8dad9c83259039970d0f2307f6